### PR TITLE
Vehicle managment overhaul + Added ability to disable minor objects + Vehicle audio and position bug fixes

### DIFF
--- a/KruFPS/KruFPS.cs
+++ b/KruFPS/KruFPS.cs
@@ -38,6 +38,14 @@ namespace KruFPS
         //private List<GameObject> Cars;
         private Dictionary<string, Transform> objectCoords;
 
+        List<GameObject> minorObjects = new List<GameObject>(); 
+        // List of all whitelisted objects that can appear on the minorObjects list
+        // Note: batteries aren't included
+        string[] listOfMinorObjects = {"ax", "beer case", "booze", "brake fluid", "cigarettes", "coffee pan", "coffee cup", "coolant", 
+        "empty plastic can", "fire extinguisher", "grill charcoal", "ground coffee", "juice", "kilju", "lamp", "macaronbox", "milk", 
+        "moosemeat", "mosquito spray", "motor oil", "oilfilter", "pike", "pizza", "potato chips", "sausages", "sugar", "spray can", 
+            "two stroke fuel", "wood carrier", "yeast" };
+
         private static float DrawDistance = 420;
         //private KeyValuePair<GameObject, Vector3> internalcars = new KeyValuePair<GameObject, Vector3>();
         public override void OnNewGame()
@@ -115,6 +123,15 @@ namespace KruFPS
             PLAYER = GameObject.Find("PLAYER");
             YARD = GameObject.Find("YARD");                     //Used to find out how far the player is from the Object
             KINEMATIC = SATSUMA.GetComponent<Rigidbody>();
+
+            // Get all minor objects from the game world (like beer cases, sausages)
+            // Only items that are in the listOfMinorObjects list, and also contain "(itemx)" in their name will be loaded
+            GameObject[] allObjects = UnityEngine.Object.FindObjectsOfType<GameObject>();
+            foreach (GameObject gameObject in allObjects)
+                foreach (string itemName in listOfMinorObjects)
+                    if (gameObject.name.Contains(itemName) && gameObject.name.Contains("(itemx)"))
+                        minorObjects.Add(gameObject);
+
             ModConsole.Print("[KruFPS] Found all objects");
             //DrawDistance = (float)RenderDistance.GetValue();
         }
@@ -133,6 +150,7 @@ namespace KruFPS
         Settings kekmet = new Settings("kekmet", "Kekmet", false);
         Settings rusko = new Settings("rusko", "Rusko", false);
         Settings cabin = new Settings("cabin", "Unload the Cabin", false);
+        Settings minorobjects = new Settings("minorObjects", "Minor objects (ex. beer cases, sausages...)", false);
         public override void ModSettings()
         {
             // All settings should be created here. 
@@ -147,6 +165,7 @@ namespace KruFPS
             Settings.AddCheckBox(this, jonnez);
             Settings.AddCheckBox(this, kekmet);
             Settings.AddCheckBox(this, rusko);
+            Settings.AddCheckBox(this, minorobjects);
             Settings.AddText(this, "Check this if you're not using it.");
             Settings.AddCheckBox(this, cabin);
             Settings.AddText(this, "Turn this down if you have a weak GPU.");
@@ -175,6 +194,11 @@ namespace KruFPS
             RUSKO.SetActive(true);
             CABIN.SetActive(true);
             KINEMATIC.isKinematic = true;
+
+            foreach (var item in minorObjects)
+            {
+                EnableDisable(item, true);
+            }
         }
 
         public override void OnGUI()
@@ -240,6 +264,12 @@ namespace KruFPS
                 {
                     EnableDisable(CABIN, ShouldEnable(PLAYER.transform, CABIN.transform));
                 }
+                if ((bool)minorobjects.GetValue() == true)
+                {
+                    foreach (GameObject obj in minorObjects)
+                        EnableDisable(obj, ShouldEnable(PLAYER.transform, obj.transform));
+                }
+
                 //Away from house
                 if (Distance(PLAYER.transform, YARD.transform) > 100) {
                     foreach(var item in awayFromHouse)

--- a/KruFPS/KruFPS.cs
+++ b/KruFPS/KruFPS.cs
@@ -23,14 +23,14 @@ namespace KruFPS
 
         private GameObject PLAYER;
         private GameObject YARD;
-        private GameObject SATSUMA;
-        private GameObject FLATBED;
-        private GameObject GIFU;
-        private GameObject HAYOSIKO;
-        private GameObject JONNEZ;
-        private GameObject KEKMET;
-        private GameObject RUSKO;
-        private GameObject FERNDALE;
+        private Vehicle SATSUMA;
+        private Vehicle FLATBED;
+        private Vehicle GIFU;
+        private Vehicle HAYOSIKO;
+        private Vehicle JONNEZ;
+        private Vehicle KEKMET;
+        private Vehicle RUSKO;
+        private Vehicle FERNDALE;
         private GameObject CABIN;
         private Rigidbody KINEMATIC;
         private List<GameObject> gameObjects;
@@ -58,7 +58,7 @@ namespace KruFPS
             gameObjects = new List<GameObject>();
             objectCoords = new Dictionary<string, Transform>();
             //Cars = new List<GameObject>();
-            
+
             //Player Vehicles
             //Cars.Add(GameObject.Find("FERNDALE(1630kg)"));
             //Cars.Add(GameObject.Find("FLATBED"));
@@ -67,14 +67,15 @@ namespace KruFPS
             //Cars.Add(GameObject.Find("JONNEZ ES(Clone)"));
             //Cars.Add(GameObject.Find("KEKMET(350-400psi)"));
             //Cars.Add(GameObject.Find("RCO_RUSCKO12(270)"));
-            SATSUMA = GameObject.Find("SATSUMA(557kg, 248)");
-            FLATBED = GameObject.Find("FLATBED");
-            GIFU = GameObject.Find("GIFU(750/450psi)");
-            HAYOSIKO = GameObject.Find("HAYOSIKO(1500kg, 250)");
-            JONNEZ = GameObject.Find("JONNEZ ES(Clone)");
-            KEKMET = GameObject.Find("KEKMET(350-400psi)");
-            RUSKO = GameObject.Find("RCO_RUSCKO12(270)");
-            FERNDALE = GameObject.Find("FERNDALE(1630kg)");
+            //SATSUMA = GameObject.Find("SATSUMA(557kg, 248)");
+            SATSUMA = new Vehicle("SATSUMA(557kg, 248)");
+            FLATBED = new Vehicle("FLATBED");
+            GIFU = new Vehicle("GIFU(750/450psi)");
+            HAYOSIKO = new Vehicle("HAYOSIKO(1500kg, 250)");
+            JONNEZ = new Vehicle("JONNEZ ES(Clone)");
+            KEKMET = new Vehicle("KEKMET(350-400psi)");
+            RUSKO = new Vehicle("RCO_RUSCKO12(270)");
+            FERNDALE = new Vehicle("FERNDALE(1630kg)");
             CABIN = GameObject.Find("CABIN");
             ModConsole.Print("Cars Done");
 
@@ -122,7 +123,7 @@ namespace KruFPS
             //Camera.main.farClipPlane = (int)RenderDistance.Value; //Helps with lower end GPU's. This specific value. Any others are wrong.
             PLAYER = GameObject.Find("PLAYER");
             YARD = GameObject.Find("YARD");                     //Used to find out how far the player is from the Object
-            KINEMATIC = SATSUMA.GetComponent<Rigidbody>();
+            KINEMATIC = SATSUMA.Object.GetComponent<Rigidbody>();
 
             // Get all minor objects from the game world (like beer cases, sausages)
             // Only items that are in the listOfMinorObjects list, and also contain "(itemx)" in their name will be loaded
@@ -185,13 +186,13 @@ namespace KruFPS
             {
                 EnableDisable(item, true); //ENABLE
             }
-            FERNDALE.SetActive(true);
-            FLATBED.SetActive(true);
-            GIFU.SetActive(true);
-            HAYOSIKO.SetActive(true);
-            JONNEZ.SetActive(true);
-            KEKMET.SetActive(true);
-            RUSKO.SetActive(true);
+            FERNDALE.EnableDisable(true);
+            FLATBED.EnableDisable(true);
+            GIFU.EnableDisable(true);
+            HAYOSIKO.EnableDisable(true);
+            JONNEZ.EnableDisable(true);
+            KEKMET.EnableDisable(true);
+            RUSKO.EnableDisable(true);
             CABIN.SetActive(true);
             KINEMATIC.isKinematic = true;
 
@@ -233,32 +234,33 @@ namespace KruFPS
                     // ^ Mild Performance Win
                     //EnableDisable(SATSUMA, ShouldEnable(PLAYER.transform, SATSUMA.transform));
                 }
-                if ((bool)flatbed.GetValue() == true){
-                    EnableDisable(FLATBED, ShouldEnable(PLAYER.transform, FLATBED.transform));
+                if ((bool)flatbed.GetValue() == true)
+                {
+                    FLATBED.EnableDisable(ShouldEnable(PLAYER.transform, FLATBED.transform));
                 }
                 if ((bool)gifu.GetValue() == true)
                 {
-                    EnableDisable(GIFU, ShouldEnable(PLAYER.transform, GIFU.transform));
+                    GIFU.EnableDisable(ShouldEnable(PLAYER.transform, GIFU.transform));
                 }
                 if ((bool)hayosiko.GetValue() == true)
                 {
-                    EnableDisable(HAYOSIKO, ShouldEnable(PLAYER.transform, HAYOSIKO.transform));
+                    HAYOSIKO.EnableDisable(ShouldEnable(PLAYER.transform, HAYOSIKO.transform));
                 }
                 if ((bool)jonnez.GetValue() == true)
                 {
-                    EnableDisable(JONNEZ, ShouldEnable(PLAYER.transform, JONNEZ.transform));
+                    JONNEZ.EnableDisable(ShouldEnable(PLAYER.transform, JONNEZ.transform));
                 }
                 if ((bool)rusko.GetValue() == true)
                 {
-                    EnableDisable(RUSKO, ShouldEnable(PLAYER.transform, RUSKO.transform));
+                    RUSKO.EnableDisable(ShouldEnable(PLAYER.transform, RUSKO.transform));
                 }
-                if((bool)ferndale.GetValue() == true)
+                if ((bool)ferndale.GetValue() == true)
                 {
-                    EnableDisable(FERNDALE, ShouldEnable(PLAYER.transform, FERNDALE.transform));
+                    FERNDALE.EnableDisable(ShouldEnable(PLAYER.transform, FERNDALE.transform));
                 }
-                if((bool)kekmet.GetValue() == true)
+                if ((bool)kekmet.GetValue() == true)
                 {
-                    EnableDisable(KEKMET, ShouldEnable(PLAYER.transform, KEKMET.transform));
+                    KEKMET.EnableDisable(ShouldEnable(PLAYER.transform, KEKMET.transform));
                 }
                 if((bool)cabin.GetValue() == true)
                 {
@@ -305,14 +307,7 @@ namespace KruFPS
             //ModConsole.Print(distance);
             try
             {
-                if (distance > distanceTarget) //100 to 200 Seems ideal
-                {
-                    return false;
-                }
-                else
-                {
-                    return true;
-                }
+                return distance < distanceTarget;
             }
             catch
             {

--- a/KruFPS/KruFPS.csproj
+++ b/KruFPS/KruFPS.csproj
@@ -54,6 +54,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Vehicle.cs" />
     <Compile Include="KruFPS.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/KruFPS/KruFPS.csproj
+++ b/KruFPS/KruFPS.csproj
@@ -35,10 +35,10 @@
       <HintPath>D:\Steam\steamapps\common\My Summer Car\mysummercar_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
     <Reference Include="MSCLoader">
-      <HintPath>D:\Steam\steamapps\common\My Summer Car\mysummercar_Data\Managed\MSCLoader.dll</HintPath>
+      <HintPath>D:\SteamLibrary\steamapps\common\My Summer Car\mysummercar_Data\Managed\MSCLoader.dll</HintPath>
     </Reference>
     <Reference Include="PlayMaker">
-      <HintPath>D:\Steam\steamapps\common\My Summer Car\mysummercar_Data\Managed\PlayMaker.dll</HintPath>
+      <HintPath>D:\SteamLibrary\steamapps\common\My Summer Car\mysummercar_Data\Managed\PlayMaker.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -47,7 +47,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>D:\Steam\steamapps\common\My Summer Car\mysummercar_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>D:\SteamLibrary\steamapps\common\My Summer Car\mysummercar_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.UI">
       <HintPath>D:\Steam\steamapps\common\My Summer Car\mysummercar_Data\Managed\UnityEngine.UI.dll</HintPath>
@@ -62,4 +62,13 @@
     <Content Include="Contributors.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>if "$(ConfigurationName)" == "Debug" (
+copy $(TargetPath) "C:\Users\aathl\Documents\MySummerCar\Mods" /y
+copy "$(TargetDir)$(TargetName).pdb" "C:\Users\aathl\Documents\MySummerCar\Mods"
+call "C:\Users\aathl\Documents\MySummerCar\Mods\debug.bat"
+) ELSE (
+copy $(TargetPath) "C:\Users\aathl\Documents\MySummerCar\Mods" /y
+)</PostBuildEvent>
+  </PropertyGroup>
 </Project>

--- a/KruFPS/Vehicle.cs
+++ b/KruFPS/Vehicle.cs
@@ -1,0 +1,106 @@
+﻿using System.Linq;
+using UnityEngine;
+
+namespace KruFPS
+{
+    class Vehicle : MonoBehaviour
+    {
+        // Vehicle class - made by Konrad "Athlon" Figura
+        // 
+        // It fixes known issue with missing vehicles engine sound by (admittedly hacky way) creating new GameObject,
+        // that stores GameObjects responsible for playing sounds in vehicle (named "audio", or "SoundSrc").
+        // Whenever the vehicle is disabled, all audio objects are changing parent to that temporary object.
+        //
+        // It also fixes the issue of vehicles going back to the original spawn position, instead of staying in the same place - as they should,
+        // by simply saving the Transform.position and Transform.rotation parameters just before disabling the object, and then loading these values,
+        // just after loading them.
+
+        public GameObject Object { get; set; }
+
+        // Values that are being saved or loaded
+        public Vector3 Position { get; set; }
+        public Quaternion Rotation { get; set; }
+
+        Transform[] AudioObjects;
+        GameObject TemporaryAudioParent;
+
+        // Overwrites the "Component.transform", to prevent eventual mod crashes caused by missuse of Vehicle.transform.
+        // Technically, you should use Vehicle.Object.transform (ex. GIFU.Object.Transform), this here just lets you use Vehicle.transform
+        // (ex. GIFU.transform).
+        public new Transform transform { get => Object.transform; }
+
+        /// <summary>
+        /// Initialize class
+        /// </summary>
+        /// <param name="gameObject"></param>
+        public Vehicle(string gameObject)
+        {
+            // Find the object by name
+            Object = GameObject.Find(gameObject);
+
+            // Dump the object position and rotation
+            Position = Object.transform.localPosition;
+            Rotation = Object.transform.localRotation;
+
+            // Get the object's child which are responsible for audio
+            AudioObjects = GetAudioObjects();
+            // Creates a new gameobject that is names after the original file + '_TEMPAUDIO' (ex. SATSUMA(557kg, 248)_TEMPAUDIO)
+            TemporaryAudioParent = new GameObject(Object.name + "_TEMPAUDIO");
+        }
+
+        /// <summary>
+        /// Retrieves the child audio objects from parent object.
+        /// Basically looks for files with "audio" and "SoundSrc" name in it
+        /// </summary>
+        /// <returns></returns>
+        Transform[] GetAudioObjects()
+        {
+            Transform[] childs = Object.transform.GetComponentsInChildren<Transform>();
+            return childs.Where(obj => obj.gameObject.name.Contains("audio") || obj.gameObject.name.Contains("SoundSrc")).ToArray();
+        }
+
+        /// <summary>
+        /// Enable or disable car
+        /// </summary>
+        public void EnableDisable(bool enabled)
+        {
+            try
+            {
+                // Don't run the code, if the value is the same
+                if (Object.activeSelf == enabled) return;
+
+                // If we're disabling a car, set the audio child parent to TemporaryAudioParent, and save the position and rotation.
+                // We're doing that BEFORE we disable the object.
+                if (!enabled)
+                {
+                    SetParentForChilds(AudioObjects, TemporaryAudioParent);
+                    Position = Object.transform.localPosition;
+                    Rotation = Object.transform.localRotation;
+                }
+
+                Object.SetActive(enabled);
+
+                // Uppon enabling the file, set the localPosition and localRotation to the object's transform, and change audio source parents to Object
+                // We're doing that AFTER we enable the object.
+                if (enabled)
+                {
+                    Object.transform.localPosition = Position;
+                    Object.transform.localRotation = Rotation;
+                    SetParentForChilds(AudioObjects, Object);
+                }
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Changes audio childs parent
+        /// </summary>
+        /// <param name="childs"></param>
+        /// <param name="newParent"></param>
+        private void SetParentForChilds(Transform[] childs, GameObject newParent)
+        {
+            foreach (Transform child in childs)
+                child.parent = newParent.transform;
+        }
+    }
+}


### PR DESCRIPTION
I added a function that allows the mod to disable some minor objects, such as beer cases, booze bottles, sausages, etc. It also adds new setting named "Minor objects (ex. beer cases, sausages...)").

First of all, there's a small performance benefit of around 5 FPS outside the home with reasonable ammount of items.

Second of all, it fixes the problem with objects ending up under the vehicles, after these vehicles had some objects inside, and the car has been unloaded.

EDIT:
Made a new Vehicle.cs class, which is supposed to manage everything related just to vehicles. It fixes the audio bug, in which the engine sound is missing, after vehicle has been deactivated, and then reactivated again (there are comments in the code that explain everything step-by-step), and also fixes vehicles teleporting to the original load position - now they will appear right where you left them :)
